### PR TITLE
Update docker-compose.grafana.yml

### DIFF
--- a/docker-compose.grafana.yml
+++ b/docker-compose.grafana.yml
@@ -29,6 +29,8 @@ services:
   grafana:
     image: grafana/grafana
     container_name: grafana
+    ports:
+      - '3000:3000'
     user: root
     volumes:
       - ./grafana/data:/var/lib/grafana # Grafana data


### PR DESCRIPTION
Cant access grafana without exposing the port 
ports:
      - '3000:3000'
      
      
This still needs to be fixed, as the Junuego service does not allow you to access port 9650 from an external IP. The Prometheus service cannot access it despite being on the same server because it's inside a docker and can't access localhost.

the only solution i got to work was using socat and then changing the port and ip to :9652 int he Prometheus.yaml
```nohup socat TCP-LISTEN:9652,fork TCP:127.0.0.1:9650 &```
