### PR TITLE
add static ip to the slg-network

### DIFF
--- a/docker-compose.grafana.yml
+++ b/docker-compose.grafana.yml
@@ -1,6 +1,5 @@
 version: '2'
 services:
-
   prometheus:
     image: prom/prometheus
     container_name: prometheus
@@ -16,7 +15,8 @@ services:
       monitoring-network:
         ipv4_address: 192.168.11.4
       slg-network:
-    
+        ipv4_address: 192.168.10.70
+
   node_exporter:
     image: prom/node-exporter
     container_name: node_exporter
@@ -24,7 +24,7 @@ services:
       - '9100:9100' # Port for Node Exporter
     networks:
       monitoring-network:
-          ipv4_address: 192.168.11.5
+        ipv4_address: 192.168.11.5
 
   grafana:
     image: grafana/grafana
@@ -39,6 +39,7 @@ services:
       monitoring-network:
         ipv4_address: 192.168.11.6
       slg-network:
+        ipv4_address: 192.168.10.80
 
 networks:
   monitoring-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       monitoring-network:
         ipv4_address: 192.168.11.4
       slg-network:
+        ipv4_address: 192.168.10.70
     logging:
       driver: 'json-file'
       options:


### PR DESCRIPTION
This is to prevent that prometheus take the ip address of the juneogo container on restart